### PR TITLE
Small refactor to ScaleTickIntervals 

### DIFF
--- a/src/shapes/scale.js
+++ b/src/shapes/scale.js
@@ -1,6 +1,6 @@
 import BaseShape from './base-shape';
 import ns from '../core/namespace';
-import ScaleTickIntervals from '../utils/scale-tick-intervals';
+import {linear as calculateLinearTicks} from '../utils/scale-tick-intervals';
 
 
 /**
@@ -73,7 +73,7 @@ export default class Scale extends BaseShape {
     }
     this.$labels = [];
 
-    const ticks = (new ScaleTickIntervals()).linear(cy0, cy1, 10);
+    const ticks = calculateLinearTicks(cy0, cy1, 10);
 
     let maxLength = ticks.reduce((acc, t) => Math.max(acc, t.label.length), 0);
     

--- a/src/utils/scale-tick-intervals.js
+++ b/src/utils/scale-tick-intervals.js
@@ -1,4 +1,3 @@
-
 /**
  * Code to calculate which values to label in a scale between two
  * endpoints, and how they should be labelled. Based on
@@ -6,137 +5,131 @@
  * library. Copyright 2017 QMUL.
  */
 
-export default class ScaleTickIntervals {
+/**
+ * Return an array of objects describing tick locations and labels,
+ * each object having "value" (number) and "label" (string)
+ * properties. All ticks will be within the range [min, max] and
+ * there will be approximately n+1 of them, dividing the range up
+ * into n divisions, although this number may vary based on which
+ * tick values seem best suited to labelling.
+ */
+export function linear(min, max, n) {
+  return explode(linearInstruction(min, max, n));
+}
 
-  constructor() { }
-  
-  /**
-   * Return an array of objects describing tick locations and labels,
-   * each object having "value" (number) and "label" (string)
-   * properties. All ticks will be within the range [min, max] and
-   * there will be approximately n+1 of them, dividing the range up
-   * into n divisions, although this number may vary based on which
-   * tick values seem best suited to labelling.
-   */
-  linear(min, max, n) {
-    let instruction = this._linearInstruction(min, max, n);
-    return this._explode(instruction);
+function linearInstruction(min, max, n) {
+  let display = "auto";
+  if (max < min) {
+    return linearInstruction(max, min, n);
   }
-
-  _linearInstruction(min, max, n) {
-    let display = "auto";
-    if (max < min) {
-      return this._linearInstruction(max, min, n);
-    }
-    if (n < 1 || max === min) {
-      return {
-	initial: min, limit: min, spacing: 1.0,
-	roundTo: min, display, precision: 1, logUnmap: false
-      };
-    }
-    if (min !== min || max !== max) {
-      // NaNs must be involved
-      console.log("ScaleTickIntervals: WARNING: min = " + min + ", max = " + max);
-      return [];
-    }
-
-    let inc = (max - min) / n;
-
-    const digInc = Math.log10(inc);
-    const digMax = Math.log10(Math.abs(max));
-    const digMin = Math.log10(Math.abs(min));
-    
-    const precInc = Math.floor(digInc);
-    const roundTo = Math.pow(10.0, precInc);
-
-    if (precInc > -4 && precInc < 4) {
-      display = "fixed";
-    } else if ((digMax >= -2.0 && digMax <= 3.0) &&
-               (digMin >= -3.0 && digMin <= 3.0)) {
-      display = "fixed";
-    } else {
-      display = "scientific";
-    }
-        
-    const precRange = Math.ceil(digMax - digInc);
-
-    let prec = 1;
-        
-    if (display === "fixed") {
-      if (digInc < 0) {
-        prec = -precInc;
-      } else {
-        prec = 0;
-      }
-    } else {
-      prec = precRange;
-    }
-
-    let minTick = min;
-        
-    if (roundTo !== 0.0) {
-      inc = Math.round(inc / roundTo) * roundTo;
-      if (inc < roundTo) inc = roundTo;
-      minTick = Math.ceil(minTick / roundTo) * roundTo;
-      if (minTick > max) minTick = max;
-    }
-
-    if (display === "scientific" && minTick !== 0.0) {
-      const digNewMin = Math.log10(Math.abs(minTick));
-      if (digNewMin < digInc) {
-        prec = Math.ceil(digMax - digNewMin);
-      }
-    }
-
+  if (n < 1 || max === min) {
     return {
-      initial: minTick, limit: max, spacing: inc,
-      roundTo, display, precision: prec, logUnmap: false
+      initial: min, limit: min, spacing: 1.0,
+      roundTo: min, display, precision: 1, logUnmap: false
     };
   }
+  if (min !== min || max !== max) {
+    // NaNs must be involved
+    console.log("ScaleTickIntervals: WARNING: min = " + min + ", max = " + max);
+    return [];
+  }
 
-  _makeTick(display, precision, value) {
-    if (display === "scientific") {
-      return { value, label: value.toExponential(precision) };
-    } else if (display === "fixed") {
-      return { value, label: value.toFixed(precision) };
+  let inc = (max - min) / n;
+
+  const digInc = Math.log10(inc);
+  const digMax = Math.log10(Math.abs(max));
+  const digMin = Math.log10(Math.abs(min));
+
+  const precInc = Math.floor(digInc);
+  const roundTo = Math.pow(10.0, precInc);
+
+  if (precInc > -4 && precInc < 4) {
+    display = "fixed";
+  } else if ((digMax >= -2.0 && digMax <= 3.0) &&
+    (digMin >= -3.0 && digMin <= 3.0)) {
+    display = "fixed";
+  } else {
+    display = "scientific";
+  }
+
+  const precRange = Math.ceil(digMax - digInc);
+
+  let prec = 1;
+
+  if (display === "fixed") {
+    if (digInc < 0) {
+      prec = -precInc;
     } else {
-      return { value, label: value.toPrecision(precision) };
+      prec = 0;
+    }
+  } else {
+    prec = precRange;
+  }
+
+  let minTick = min;
+
+  if (roundTo !== 0.0) {
+    inc = Math.round(inc / roundTo) * roundTo;
+    if (inc < roundTo) inc = roundTo;
+    minTick = Math.ceil(minTick / roundTo) * roundTo;
+    if (minTick > max) minTick = max;
+  }
+
+  if (display === "scientific" && minTick !== 0.0) {
+    const digNewMin = Math.log10(Math.abs(minTick));
+    if (digNewMin < digInc) {
+      prec = Math.ceil(digMax - digNewMin);
     }
   }
 
-  _explode(instruction) {
+  return {
+    initial: minTick, limit: max, spacing: inc,
+    roundTo, display, precision: prec, logUnmap: false
+  };
+}
 
-    if (instruction.spacing === 0.0) {
-      return [];
-    }
-
-    let eps = 1e-7;
-    if (instruction.spacing < eps * 10.0) {
-      eps = instruction.spacing / 10.0;
-    }
-
-    const max = instruction.limit;
-    let n = 0;
-
-    let ticks = [];
-        
-    while (true) {
-      let value = instruction.initial + n * instruction.spacing;
-      if (value >= max + eps) {
-        break;
-      }
-      if (instruction.logUnmap) {
-        value = Math.pow(10.0, value);
-      }
-      if (instruction.roundTo !== 0.0) {
-        value = instruction.roundTo * Math.round(value / instruction.roundTo);
-      }
-      ticks.push(this._makeTick(instruction.display,
-                                instruction.precision,
-                                value));
-      ++n;
-    }
-
-    return ticks;
+function makeTick(display, precision, value) {
+  if (display === "scientific") {
+    return {value, label: value.toExponential(precision)};
+  } else if (display === "fixed") {
+    return {value, label: value.toFixed(precision)};
+  } else {
+    return {value, label: value.toPrecision(precision)};
   }
+}
+
+function explode(instruction) {
+
+  if (instruction.spacing === 0.0) {
+    return [];
+  }
+
+  let eps = 1e-7;
+  if (instruction.spacing < eps * 10.0) {
+    eps = instruction.spacing / 10.0;
+  }
+
+  const max = instruction.limit;
+  let n = 0;
+
+  let ticks = [];
+
+  while (true) {
+    let value = instruction.initial + n * instruction.spacing;
+    if (value >= max + eps) {
+      break;
+    }
+    if (instruction.logUnmap) {
+      value = Math.pow(10.0, value);
+    }
+    if (instruction.roundTo !== 0.0) {
+      value = instruction.roundTo * Math.round(value / instruction.roundTo);
+    }
+    ticks.push(makeTick(instruction.display,
+      instruction.precision,
+      value));
+    ++n;
+  }
+
+  return ticks;
 }


### PR DESCRIPTION
I figure the class was being used for two things before: implementation hiding and as a sort of namespace.

The ES2015 modules can serve for both here really, the module groups the related code and only the desired public functionality is exported. Naming is then the only issue, as you don't get the context you'd get in C++ with namespaces `ScaleTickIntervals::linear` vs `linear` here. You'd get that with a static class here too `ScaleTickIntervals.linear`. I leave it as linear, but alias it when importing. 

This is a real nitpick-y PR. Forgive me. 